### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     branches: [master]
     tags: ['v*']
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/andusch/aqua/security/code-scanning/1](https://github.com/andusch/aqua/security/code-scanning/1)

To fix the problem, explicitly define a `permissions` block so the `GITHUB_TOKEN` is limited to the least privilege needed. Since this workflow only checks out code and uploads build artifacts, it does not need write access to repository contents or other GitHub resources. A minimal and appropriate permission is `contents: read`. Defining this at the workflow root will apply to all jobs that don’t override it, which matches the current single-job setup.

Concretely, in `.github/workflows/release.yml`, add a `permissions:` section near the top, alongside `name:` and `on:`. For example, after the `on:` block and before `jobs:`, insert:

```yaml
permissions:
  contents: read
```

No additional imports or methods are needed because this is a YAML workflow configuration change only, and none of the existing steps rely on elevated token permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
